### PR TITLE
Add filter support to our client

### DIFF
--- a/src/amqp10_client.erl
+++ b/src/amqp10_client.erl
@@ -40,6 +40,7 @@
          attach_receiver_link/3,
          attach_receiver_link/4,
          attach_receiver_link/5,
+         attach_receiver_link/6,
          attach_link/2,
          detach_link/1,
          send_msg/2,
@@ -63,6 +64,7 @@
 
 -type attach_role() :: amqp10_client_session:attach_role().
 -type attach_args() :: amqp10_client_session:attach_args().
+-type filter() :: amqp10_client_session:filter().
 
 -type connection_config() :: amqp10_client_connection:connection_config().
 
@@ -244,11 +246,22 @@ attach_receiver_link(Session, Name, Source, SettleMode) ->
                            snd_settle_mode(), terminus_durability()) ->
     {ok, link_ref()}.
 attach_receiver_link(Session, Name, Source, SettleMode, Durability) ->
+    attach_receiver_link(Session, Name, Source, SettleMode, Durability, #{}).
+
+%% @doc Attaches a receiver link to a source.
+%% This is asynchronous and will notify completion of the attach request to the
+%% caller using an amqp10_event of the following format:
+%% {amqp10_event, {link, LinkRef, attached | {detached, Why}}}
+-spec attach_receiver_link(pid(), binary(), binary(),
+                           snd_settle_mode(), terminus_durability(), filter()) ->
+    {ok, link_ref()}.
+attach_receiver_link(Session, Name, Source, SettleMode, Durability, Filter) ->
     AttachArgs = #{name => Name,
                    role => {receiver, #{address => Source,
                                         durable => Durability}, self()},
                    snd_settle_mode => SettleMode,
-                   rcv_settle_mode => first},
+                   rcv_settle_mode => first,
+                   filter => Filter},
     amqp10_client_session:attach(Session, AttachArgs).
 
 -spec attach_link(pid(), attach_args()) -> {ok, link_ref()}.

--- a/src/amqp10_client_session.erl
+++ b/src/amqp10_client_session.erl
@@ -91,10 +91,15 @@
                         durable => terminus_durability()}.
 
 -type attach_role() :: {sender, target_def()} | {receiver, source_def(), pid()}.
+
+% http://www.amqp.org/specification/1.0/filters
+-type filter() :: #{binary() => binary() | map() | list(binary())}.
+
 -type attach_args() :: #{name => binary(),
                          role => attach_role(),
                          snd_settle_mode => snd_settle_mode(),
-                         rcv_settle_mode => rcv_settle_mode()
+                         rcv_settle_mode => rcv_settle_mode(),
+                         filter => filter()
                         }.
 
 -type link_ref() :: #link_ref{}.
@@ -105,7 +110,8 @@
               attach_args/0,
               attach_role/0,
               target_def/0,
-              source_def/0]).
+              source_def/0,
+              filter/0]).
 
 -record(link,
         {name :: link_name(),
@@ -633,10 +639,12 @@ build_frames(Channel, Trf, Payload, MaxPayloadSize, Acc) ->
 
 make_source(#{role := {sender, _}}) ->
     #'v1_0.source'{};
-make_source(#{role := {receiver, #{address := Address} = Target, _Pid}}) ->
+make_source(#{role := {receiver, #{address := Address} = Target, _Pid}, filter := Filter}) ->
     Durable = translate_terminus_durability(maps:get(durable, Target, none)),
+    TranslatedFilter = translate_filters(Filter),
     #'v1_0.source'{address = {utf8, Address},
-                   durable = {uint, Durable}}.
+                   durable = {uint, Durable},
+                   filter = TranslatedFilter}.
 
 make_target(#{role := {receiver, #{target_address := Address} = Target, _Pid}}) ->
     Durable = translate_terminus_durability(maps:get(durable, Target, none)),
@@ -652,6 +660,42 @@ make_target(#{role := {sender, #{address := Address} = Target}}) ->
 translate_terminus_durability(none) -> 0;
 translate_terminus_durability(configuration) -> 1;
 translate_terminus_durability(unsettled_state) -> 2.
+
+translate_filters(Filters) when is_map(Filters) andalso map_size(Filters) =< 0 -> undefined;
+translate_filters(Filters) when is_map(Filters) -> {
+    map,
+    maps:fold(
+        fun(<<"apache.org:legacy-amqp-direct-binding:string">> = K, V, Acc) when is_binary(V) ->
+            [{{symbol, K}, {described, {symbol, K}, {utf8, V}}} | Acc];
+        (<<"apache.org:legacy-amqp-topic-binding:string">> = K, V, Acc) when is_binary(V) ->
+            [{{symbol, K}, {described, {symbol, K}, {utf8, V}}} | Acc];
+        (<<"apache.org:legacy-amqp-headers-binding:map">> = K, V, Acc) when is_map(V) ->
+            [{{symbol, K}, {described, {symbol, K}, translate_legacy_amqp_headers_binding(V)}} | Acc];
+        (<<"apache.org:no-local-filter:list">> = K, V, Acc) when is_list(V) ->
+            [{{symbol, K}, {described, {symbol, K}, lists:map(fun(Id) -> {utf8, Id} end, V)}} | Acc];
+        (<<"apache.org:selector-filter:string">> = K, V, Acc) when is_binary(V) ->
+            [{{symbol, K}, {described, {symbol, K}, {utf8, V}}} | Acc]
+        end,
+        [],
+        Filters)
+}.
+
+% https://people.apache.org/~rgodfrey/amqp-1.0/apache-filters.html
+translate_legacy_amqp_headers_binding(LegacyHeaders) -> {
+    map,
+    maps:fold(
+        fun(<<"x-match">> = K, <<"any">> = V, Acc) ->
+            [{{utf8, K}, {utf8, V}} | Acc];
+        (<<"x-match">> = K, <<"all">> = V, Acc) ->
+            [{{utf8, K}, {utf8, V}} | Acc];
+        (<<"x-",_/binary>>, _, Acc) ->
+            Acc;
+        (K, V, Acc) ->
+            [{{utf8, K}, {utf8, V}} | Acc]
+        end,
+        [],
+        LegacyHeaders)
+}.
 
 send_detach(Send, {detach, OutHandle}, _From, State = #state{links = Links}) ->
     case Links of


### PR DESCRIPTION
This backports the relevant upstream changes found here:

- https://github.com/rabbitmq/rabbitmq-amqp1.0-client/pull/17/files
- https://github.com/rabbitmq/rabbitmq-amqp1.0-client/pull/28/files

To add filter support to our fork of the amqp client